### PR TITLE
Update CODEOWNERS: remove deprecated group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 # .pre-commit-config.yaml @wusatosi # Add other project owners here
 # .markdownlint.yaml @wusatosi # Add other project owners here
 
-*  @bretbrownjr @dietmarkuehl @neatudarius @steve-downey @wusatosi @bemanproject/core-reviewers
+*  @bretbrownjr @dietmarkuehl @steve-downey @wusatosi


### PR DESCRIPTION
Update CODEOWNERS: remove deprecated group https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#repositorycodeowners