### PR TITLE
Bump execution and net dependencies to latest

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,6 +24,8 @@ jobs:
           {"preset": "gcc-release", "image": "ghcr.io/bemanproject/infra-containers-gcc:latest"},
           {"preset": "llvm-debug", "image": "ghcr.io/bemanproject/infra-containers-clang:latest"},
           {"preset": "llvm-release", "image": "ghcr.io/bemanproject/infra-containers-clang:latest"},
+          {"preset": "appleclang-debug", "runner": "macos-latest"},
+          {"preset": "appleclang-release", "runner": "macos-latest"},
           {"preset": "msvc-debug", "runner": "windows-latest"},
           {"preset": "msvc-release", "runner": "windows-latest"}
         ]
@@ -46,14 +48,14 @@ jobs:
                     }
                   ]
                 },
-                { "cxxversions": ["c++23"],
+                { "cxxversions": ["c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
             },
             { "versions": ["14", "13"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -72,7 +74,7 @@ jobs:
                     }
                   ]
                 },
-                { "cxxversions": ["c++23"],
+                { "cxxversions": ["c++23", "c++20"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -81,7 +83,7 @@ jobs:
             },
             { "versions": ["19", "18"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -90,8 +92,17 @@ jobs:
             },
             { "versions": ["17"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
+                }
+              ]
+            }
+          ],
+          "appleclang": [
+            { "versions": ["latest"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++23", "c++20"],
+                  "tests": [{ "stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 }
               ]
             }
@@ -103,6 +114,13 @@ jobs:
                   "tests": [
                     { "stdlibs": ["stl"],
                       "tests": ["Debug.Default", "Release.Default", "Release.MaxSan"]
+                    }
+                  ]
+                },
+                { "cxxversions": ["c++20"],
+                  "tests": [
+                    { "stdlibs": ["stl"],
+                      "tests": ["Release.Default"]
                     }
                   ]
                 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,14 @@ FetchContent_Declare(
     execution
     # SOURCE_DIR <path-to>/execution
     GIT_REPOSITORY https://github.com/bemanproject/execution
-    GIT_TAG 578c05
+    GIT_TAG fa6d441
 )
 FetchContent_MakeAvailable(execution)
 FetchContent_Declare(
     net
     # SOURCE_DIR <path-to>/net
     GIT_REPOSITORY https://github.com/bemanproject/net
-    GIT_TAG 53a8738
+    GIT_TAG ea1fd8f
 )
 if(NOT WIN32)
     FetchContent_MakeAvailable(net)


### PR DESCRIPTION
Also update CI to:

- Add support for testing C++20 with every compiler,
- Remove the C++17 test that was accidentally added,
- Add support for testing AppleClang